### PR TITLE
Allow the use of IAM instance roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source :gemcutter
 gem "mongo"
 # crappy dependencies
 gem "bson_ext"
-gem "fog"
+gem "fog" # <3
 gem "trollop"
+gem "json"
+gem "open-uri"

--- a/README.markdown
+++ b/README.markdown
@@ -43,6 +43,9 @@ This will force detach and destroy all the volumes previously connected for the 
 
 ### Usage with IAM
 
+Note that the -a and -s (access key and secret key) flags are no longer required.
+If you have set up an IAM instance role for your instance, the backup and restore commands will retrieve temporary AWS credentials from the Instance Metadata Service.
+
 If you use IAM for your authentication in EC2, here is a probably up to date list of the permissions you need to grant:
 
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,14 +1,14 @@
 require 'rake'
 require "rake/clean"
-require 'rake/gempackagetask'
-require 'rake/rdoctask'
+require 'rubygems/package_task'
+require 'rdoc/task'
 
 desc "Packages up the gem."
 task :default => :package
 
 spec = Gem::Specification.new do |s|
   s.name    = 'mongo-ec2-backup'
-  s.version = '0.0.8'
+  s.version = '0.0.9'
   s.summary = 'Snapshot your mongodb in the EC2 cloud via XFS Freeze'
 
   s.author   = 'Pierre Baillet'
@@ -20,6 +20,7 @@ spec = Gem::Specification.new do |s|
   s.add_dependency 'bson_ext'
   s.add_dependency 'trollop'
   s.add_dependency 'mongo'
+  s.add_dependency 'json'
 
   # Include everything in the lib folder
   s.files = FileList['lib/**/*.rb', 'bin/*', '[A-Z]*', 'test/**/*'].to_a
@@ -31,7 +32,7 @@ spec = Gem::Specification.new do |s|
   s.rubyforge_project = 'nowarning'
 end
 
-Rake::GemPackageTask.new(spec) do |package| 
+Gem::PackageTask.new(spec) do |package|
   package.gem_spec = spec
   # package.need_tar = true 
   # package.need_zip = true

--- a/bin/ec2_snapshot_restorer
+++ b/bin/ec2_snapshot_restorer
@@ -50,8 +50,8 @@ class SnapshotRestorer
     return snapshots
   end
 
-  def prepare_volumes(dest_instance)
-    @snaps.each do | resource_id |
+  def prepare_volumes(dest_instance, piops = nil)
+    @snaps.each do |resource_id|
       snap = @compute.snapshots.get(resource_id)
       # Snap have the following tags
       # application
@@ -61,7 +61,11 @@ class SnapshotRestorer
       # kind
 
       t =  snap.tags
-      volume = @compute.volumes.new :snapshot_id => snap.id, :size => snap.volume_size, :availability_zone => @ec2.availability_zone
+      if piops
+        volume = @compute.volumes.new :snapshot_id => snap.id, :size => snap.volume_size, :availability_zone => @ec2.availability_zone, :type => 'io1', :iops => piops
+      else
+        volume = @compute.volumes.new :snapshot_id => snap.id, :size => snap.volume_size, :availability_zone => @ec2.availability_zone
+      end
       volume.save
       volume.reload
       @compute.create_tags(volume.id, { "application" => t['application'],
@@ -137,6 +141,7 @@ opts = Trollop::options do
   opt :type, "Snapshot type to restore, defaults to snapshot", :type => :string, :default => 'snapshot'
   opt :target, "Creates volume ready for mounting on instance id. Use special value SELF to restore here", :type => :string
   opt :first_device, "First device to attach to (default is to use source first device) /dev/sdx", :type => :string
+  opt :provisioned_iops, "Creates provisioned IOPS volumes from snapshots.  Supply an IOPS value.", :type => :integer
   opt :action, 'Action', :default => 'attach'
 end
   
@@ -165,7 +170,7 @@ else
         raise "First device has to be indicated"
       end
       puts "Preparing volumes for instance #{target}"
-      s.prepare_volumes(target)
+      s.prepare_volumes(target, opts[:provisioned_iops])
       # Need to clone, because trollop freeze the variable
 
       s.rattach_volumes(opts[:first_device])

--- a/bin/ec2_snapshot_restorer
+++ b/bin/ec2_snapshot_restorer
@@ -3,11 +3,10 @@
 require 'rubygems'
 require 'trollop'
 require 'fog'
-require 'open-uri'
-require 'trollop'
 require 'pp'
-$: << File.join(File.dirname(__FILE__), "../lib")
+require 'open-uri'
 require 'ec2_instance_identifier'
+require 'ec2_helper'
 
 
 DEBUG=false
@@ -15,17 +14,19 @@ DEBUG=false
 def log what
   puts what if DEBUG
 end
-# 
+
 class SnapshotRestorer
   attr_accessor :snaps
+
   def initialize(aki, sak)
-    @compute = Fog::Compute.new({:provider => 'AWS', :aws_access_key_id => aki, :aws_secret_access_key => sak})
+    @ec2 = EC2Helper.new(aki, sak)
+    @compute = Fog::Compute.new(@ec2.connection)
     @snaps = []
     @volumes = []
   end
+
   def find_snapshots(instance_id, kind = 'snapshot')
     log "Looking for snapshots for #{instance_id}"
-    volume_map = []
     snapshots = {}
 
     tags = @compute.tags.all(:key => 'instance_id', :value => instance_id)
@@ -48,6 +49,7 @@ class SnapshotRestorer
     snapshots['LATEST'] = snapshots[max_date] if snapshots[max_date]
     return snapshots
   end
+
   def prepare_volumes(dest_instance)
     @snaps.each do | resource_id |
       snap = @compute.snapshots.get(resource_id)
@@ -59,7 +61,7 @@ class SnapshotRestorer
       # kind
 
       t =  snap.tags
-      volume = @compute.volumes.new :snapshot_id => snap.id, :size => snap.volume_size, :availability_zone => 'us-east-1c'
+      volume = @compute.volumes.new :snapshot_id => snap.id, :size => snap.volume_size, :availability_zone => @ec2.availability_zone
       volume.save
       volume.reload
       @compute.create_tags(volume.id, { "application" => t['application'],
@@ -72,6 +74,7 @@ class SnapshotRestorer
       @volumes << volume
     end
   end
+
   def rattach_volumes(base_device = nil)
     dest = base_device
     if !dest
@@ -86,6 +89,7 @@ class SnapshotRestorer
       dest.next!
     end
   end
+
   def find_volume_for_instance_and_snapshots(dest_instance)
     vols = []
     @snaps.each do | resource_id |
@@ -98,6 +102,7 @@ class SnapshotRestorer
     end
     return vols
   end
+
   def detach_snapshots(dest_instance)
     vols = find_volume_for_instance_and_snapshots(dest_instance)
     if vols.length == 0
@@ -117,13 +122,17 @@ class SnapshotRestorer
       v.destroy()
     end
   end
+
+  def get_instance_id_from_metadata
+    open('http://169.254.169.254/latest/meta-data/instance-id').readline
+  end
 end
 
 
 opts = Trollop::options do
-  opt :hostname, "Hostname tag to use to find the instance", :type => :string, :required => true
-  opt :access_key_id, "Access Key Id for AWS", :type => :string, :required => true
-  opt :secret_access_key, "Secret Access Key for AWS", :type => :string, :required => true
+  opt :hostname, "Hostname tag to use to find the instance", :type => :string
+  opt :access_key_id, "Access Key Id for AWS", :type => :string
+  opt :secret_access_key, "Secret Access Key for AWS", :type => :string
   opt :date, "Date to restore, use LATEST to take latest data", :type => :string
   opt :type, "Snapshot type to restore, defaults to snapshot", :type => :string, :default => 'snapshot'
   opt :target, "Creates volume ready for mounting on instance id. Use special value SELF to restore here", :type => :string
@@ -131,12 +140,11 @@ opts = Trollop::options do
   opt :action, 'Action', :default => 'attach'
 end
   
-finder = EC2InstanceIdentifier.new(opts[:access_key_id], opts[:secret_access_key])
-instance_identifier = finder.get_instance(opts[:hostname]).id
+instance_identifier = EC2InstanceIdentifier.new(opts[:access_key_id], opts[:secret_access_key])
 s = SnapshotRestorer.new(opts[:access_key_id], opts[:secret_access_key])
 
 # Find this instance snapshots
-snaps = s.find_snapshots(instance_identifier, opts[:type])
+snaps = s.find_snapshots(instance_identifier.get_instance(opts[:hostname]), opts[:type])
 
 if ! opts[:date] || !snaps.has_key?(opts[:date])
   puts "We have found the following snapshot's dates:"
@@ -151,7 +159,7 @@ else
   if opts[:target]
     s.snaps = snaps[opts[:date]].map{ |s| s.id }
     target = opts[:target]
-    target = open("http://169.254.169.254/latest/meta-data/instance-id").read if target == "SELF"
+    target = s.get_instance_id_from_metadata if target == "SELF"
     if opts[:action] == 'attach'
       if !opts[:first_device]
         raise "First device has to be indicated"

--- a/bin/mongo_lock_and_snapshot
+++ b/bin/mongo_lock_and_snapshot
@@ -2,7 +2,6 @@
 # Lock a set of disk via the mongo lock command and snapshot them to the cloud
 
 require 'rubygems'
-require 'bundler/setup'
 require 'trollop'
 
 $: << File.join("..", File.dirname(__FILE__), "lib")
@@ -29,7 +28,16 @@ aki = opts[:access_key_id]
 sak = opts[:secret_access_key]
 path = opts[:path]
 
-`/usr/sbin/xfs_freeze -f #{path}`
+def log s
+  $stderr.puts "[#{Time.now}]: #{s}"
+end
+
+db = MongoHelper::DataLocker.new
+db.lock
+if db.locked?
+  log "MongoDB oplog time is #{db.getOplogTime}"
+  `/usr/sbin/xfs_freeze -f #{path}`
+end
 
 begin
   snapshotter = EC2VolumeSnapshotter.new(aki, sak)
@@ -39,11 +47,12 @@ begin
     opts[:limit]
   end
 
-  snapshotter.snapshot_devices(opts[:devices].split(/,/), "Mongo Snapshot", opts[:type], limit)
+  snapshotter.snapshot_devices(opts[:devices].split(/,/), "Mongo Snapshot", opts[:type], limit, "oplogtime = #{db.getOplogTime}")
 rescue Exception => e
   require "pp"
   puts e.inspect  
   pp e.backtrace
 ensure
+  db.unlock
   `/usr/sbin/xfs_freeze -u #{path}`
 end

--- a/bin/mongo_lock_and_snapshot
+++ b/bin/mongo_lock_and_snapshot
@@ -6,15 +6,15 @@ require 'bundler/setup'
 require 'trollop'
 
 $: << File.join("..", File.dirname(__FILE__), "lib")
-require 'ec2-consistent-backup'
-require 'ec2_volume_snapshoter'
+require 'ec2_consistent_backup'
+require 'ec2_volume_snapshotter'
 
 opts = Trollop::options do
   opt :path, "Data path to freeze", :type => :string, :required => true
-  opt :access_key_id, "Access Key Id for AWS", :type => :string, :required => true
-  opt :secret_access_key, "Secret Access Key for AWS", :type => :string, :required => true
+  opt :access_key_id, "Access Key Id for AWS", :type => :string
+  opt :secret_access_key, "Secret Access Key for AWS", :type => :string
   opt :devices, "Devices to snapshot, comma separated", :type => :string, :required => true
-  opt :type, "Snapshot type, to choose among #{EC2VolumeSnapshoter::KINDS.keys.join(",")}", :default => "snapshot"
+  opt :type, "Snapshot type, to choose among #{EC2VolumeSnapshotter::KINDS.keys.join(",")}", :default => "snapshot"
   opt :limit, "Cleanup old snapshots to keep only limit snapshots", :type => :integer
 end
 
@@ -32,14 +32,14 @@ path = opts[:path]
 `/usr/sbin/xfs_freeze -f #{path}`
 
 begin
-  snapshoter = EC2VolumeSnapshoter.new(aki, sak)
+  snapshotter = EC2VolumeSnapshotter.new(aki, sak)
   limit = if opts[:limit] == nil
-    EC2VolumeSnapshoter::KINDS[opts[:type]]
+    EC2VolumeSnapshotter::KINDS[opts[:type]]
   else
     opts[:limit]
   end
 
-  snapshoter.snapshot_devices(opts[:devices].split(/,/), "Mongo Snapshot", opts[:type], limit)
+  snapshotter.snapshot_devices(opts[:devices].split(/,/), "Mongo Snapshot", opts[:type], limit)
 rescue Exception => e
   require "pp"
   puts e.inspect  

--- a/bin/mongo_lock_and_snapshot
+++ b/bin/mongo_lock_and_snapshot
@@ -47,7 +47,7 @@ begin
     opts[:limit]
   end
 
-  snapshotter.snapshot_devices(opts[:devices].split(/,/), "Mongo Snapshot", opts[:type], limit, "oplogtime = #{db.getOplogTime}")
+  snapshotter.snapshot_devices(opts[:devices].split(/,/), "Mongo Snapshot", opts[:type], limit, {"mongo_oplogtime" => db.getOplogTime})
 rescue Exception => e
   require "pp"
   puts e.inspect  

--- a/lib/ec2_helper.rb
+++ b/lib/ec2_helper.rb
@@ -1,0 +1,70 @@
+require 'open-uri'
+require 'json'
+require 'fog'
+
+# Support IAM instance profiles
+class EC2Helper
+
+  # Need access_key_id, secret_access_key
+  def initialize(aki, sak)
+    @aki = aki
+    @sak = sak
+    @gettoken = false
+  end
+
+  def connection
+    if token.nil?
+      {:provider => 'AWS', :aws_access_key_id => access_key, :aws_secret_access_key => secret_key, :region => region}
+    else
+      {:provider => 'AWS', :aws_access_key_id => access_key, :aws_secret_access_key => secret_key, :aws_session_token => token, :region => region}
+    end
+  end
+
+  def access_key
+    if @aki.nil?
+      creds = get_creds_from_metadata
+      @aki = creds['AccessKeyId']
+      @gettoken = true
+    end
+    @aki
+  end
+
+  def secret_key
+    if @sak.nil?
+      creds = get_creds_from_metadata
+      @sak = creds['SecretAccessKey']
+      @gettoken = true
+    end
+    @sak
+  end
+
+  def token
+    get_creds_from_metadata['Token]'] if @gettoken
+  end
+
+  def iam_role
+    open('http://169.254.169.254/latest/meta-data/iam/security-credentials').readline
+  end
+
+  def instance_id
+    open('http://169.254.169.254/latest/meta-data/instance-id').readline
+  end
+
+  def region
+    open('http://169.254.169.254/latest/meta-data/placement/availability-zone').readline[0..-2]
+  end
+
+  def availability_zone
+    open('http://169.254.169.254/latest/meta-data/placement/availability-zone').readline
+  end
+  
+  private
+
+  def get_creds_from_metadata
+    begin
+      JSON.parse(open("http://169.254.169.254/latest/meta-data/iam/security-credentials/#{iam_role}").read)
+    rescue OpenURI::HTTPError => e
+      { 'AccessKeyId' => nil, 'SecretAccessKey' => nil, 'Token' => nil }
+    end
+  end
+end

--- a/lib/ec2_helper.rb
+++ b/lib/ec2_helper.rb
@@ -9,22 +9,20 @@ class EC2Helper
   def initialize(aki, sak)
     @aki = aki
     @sak = sak
-    @gettoken = false
+    @token = nil
   end
 
   def connection
-    if token.nil?
-      {:provider => 'AWS', :aws_access_key_id => access_key, :aws_secret_access_key => secret_key, :region => region}
-    else
-      {:provider => 'AWS', :aws_access_key_id => access_key, :aws_secret_access_key => secret_key, :aws_session_token => token, :region => region}
-    end
+    connection = {:provider => 'AWS', :aws_access_key_id => access_key, :aws_secret_access_key => secret_key, :region => region}
+    connection.merge!({ :aws_session_token => @token }) unless @token.nil?
+    connection
   end
 
   def access_key
     if @aki.nil?
       creds = get_creds_from_metadata
       @aki = creds['AccessKeyId']
-      @gettoken = true
+      @token = creds['Token']
     end
     @aki
   end
@@ -33,13 +31,13 @@ class EC2Helper
     if @sak.nil?
       creds = get_creds_from_metadata
       @sak = creds['SecretAccessKey']
-      @gettoken = true
+      @token = creds['Token']
     end
     @sak
   end
 
   def token
-    get_creds_from_metadata['Token]'] if @gettoken
+    get_creds_from_metadata['Token']
   end
 
   def iam_role
@@ -57,7 +55,7 @@ class EC2Helper
   def availability_zone
     open('http://169.254.169.254/latest/meta-data/placement/availability-zone').readline
   end
-  
+
   private
 
   def get_creds_from_metadata

--- a/lib/ec2_instance_identifier.rb
+++ b/lib/ec2_instance_identifier.rb
@@ -1,19 +1,27 @@
 require 'resolv'
 require 'fog'
+$: << File.join(File.dirname(__FILE__), "../lib")
+require 'ec2_helper'
 
 class EC2InstanceNotFoundException < Exception; end
+
 # Fetch an instance from its private ip address
 class EC2InstanceIdentifier
-  # Need access_key_id, secret_access_key
   def initialize(aki, sak)
-    @compute = Fog::Compute.new({:provider => 'AWS', :aws_access_key_id => aki, :aws_secret_access_key => sak})
+    @ec2 = EC2Helper.new(aki, sak)
+    @compute = Fog::Compute.new(@ec2.connection)
   end
+
   # Returns the instance corresponding to the provided hostname
   def get_instance(hostname)
-    ip = Resolv.getaddress(hostname)
-    instance = @compute.servers.all().find { |i| i.private_ip_address  == ip || i.public_ip_address == ip }
-    raise InstanceNotFoundException.new(hostname) if ! instance
-    return instance
+    if hostname.nil?
+      @ec2.instance_id
+    else
+      ip = Resolv.getaddress(hostname)
+      instance = @compute.servers.all().find { |i| i.private_ip_address  == ip || i.public_ip_address == ip }
+      raise InstanceNotFoundException.new(hostname) if ! instance
+      instance.id
+    end
   end
 end
 
@@ -21,12 +29,11 @@ if __FILE__ == $0
   require 'trollop'
   require 'pp'
   opts = Trollop::options do
-    opt :access_key_id, "Access Key Id for AWS", :type => :string, :required => true
-    opt :secret_access_key, "Secret Access Key for AWS", :type => :string, :required => true
-    opt :hostname, "Hostname to look for. Should resolve to a local EC2 Ip", :type => :string, :required => true
+    opt :access_key_id, "Access Key Id for AWS", :type => :string
+    opt :secret_access_key, "Secret Access Key for AWS", :type => :string
+    opt :hostname, "Hostname to look for. Should resolve to a local EC2 Ip", :type => :string
   end
 
   eii = EC2InstanceIdentifier.new(opts[:access_key_id], opts[:secret_access_key])
   pp eii.get_instance(opts[:hostname])
-
 end

--- a/lib/ec2_volume_snapshotter.rb
+++ b/lib/ec2_volume_snapshotter.rb
@@ -61,6 +61,8 @@ class EC2VolumeSnapshotter
 
     log "Snapshot of kind #{kind}, limit set to #{limit} (0 means never purge)"
     ts = DateTime.now.to_s
+    t = Time.new
+    backup_id = sprintf("%4d%02d%02d.%02d", t.year, t.month, t.day, t.hour)
     name = "#{NAME_PREFIX}:" + name
     volumes = {}
     devices.each do |device|
@@ -80,6 +82,7 @@ class EC2VolumeSnapshotter
       @compute.tags.create(:resource_id => snapshot.id, :key =>"instance_id", :value =>@instance_id)
       @compute.tags.create(:resource_id => snapshot.id, :key =>"date", :value => ts)
       @compute.tags.create(:resource_id => snapshot.id, :key =>"kind", :value => kind)
+      @compute.tags.create(:resource_id => snapshot.id, :key =>"backup_id", :value => backup_id)
       if comments.is_a? Hash
         comments.each do |k, v = nil|
           @compute.tags.create(:resource_id => snapshot.id, :key => k, :value => v)

--- a/lib/ec2_volume_snapshotter.rb
+++ b/lib/ec2_volume_snapshotter.rb
@@ -1,7 +1,9 @@
 require 'fog'
-require 'open-uri'
+require 'pp'
+$: << File.join(File.dirname(__FILE__), "../lib")
+require 'ec2_helper'
 
-# This class is responsible of the snapshoting of given disks to EC2
+# This class is responsible of the snapshotting of given disks to EC2
 # EC2 related permissions in IAM
 # Sid": "Stmt1344254048404",
 #      "Action": [
@@ -22,6 +24,7 @@ class NoSuchVolumeException < Exception
   def initialize(instance, volume, details)
     @instance, @volume, @details = instance, volume, details
   end
+
   def to_s
     "Unable to locate volume \"#{@volume}\" on #{@instance}\nKnow volumes for this instance are:\n#{@details.inspect}"
   end
@@ -31,8 +34,8 @@ def log s
  $stderr.puts "[#{Time.now}]: #{s}"
 end
 
-class EC2VolumeSnapshoter
-  NAME_PREFIX='Volume Snapshot'
+class EC2VolumeSnapshotter
+  NAME_PREFIX='Volume Snapshot' # TODO: make this not a constant
 
   # Kind of snapshot and their expiration in days
   KINDS = { 'test' => 1,
@@ -43,18 +46,18 @@ class EC2VolumeSnapshoter
     'yearly' => 0}
 
   attr_reader :instance_id
-  # Need access_key_id, secret_access_key and instance_id
+
   # If not provided, attempt to fetch current instance_id
-  def initialize(aki, sak, instance_id = open("http://169.254.169.254/latest/meta-data/instance-id").read)
-
-    @instance_id = instance_id
-
-    @compute = Fog::Compute.new({:provider => 'AWS', :aws_access_key_id => aki, :aws_secret_access_key => sak})
+  def initialize(aki, sak, instance_id = nil)
+    @ec2 = EC2Helper.new(aki, sak)
+    @compute = Fog::Compute.new(@ec2.connection)
+    @instance_id = instance_id.nil? ? @ec2.instance_id : instance_id
   end
+
   # Snapshots the list of devices 
   # devices is an array of device attached to the instance (/dev/foo)
   # name if the name of the snapshot
-  def snapshot_devices(devices, name = "#{instance_id}", kind = "test", limit = KINDS[kind])
+  def snapshot_devices(devices, name = "#{@instance_id}", kind = "test", limit = KINDS[kind])
     log "Snapshot of kind #{kind}, limit set to #{limit} (0 means never purge)"
     ts = DateTime.now.to_s
     name = "#{NAME_PREFIX}:" + name
@@ -64,7 +67,7 @@ class EC2VolumeSnapshoter
     end
     sn = []
     volumes.each do |device, volume|
-      log "Creating volume snapshot for #{device} on instance #{instance_id}"
+      log "Creating volume snapshot for #{device} on instance #{@instance_id}"
       snapshot = volume.snapshots.new
       snapshot.description = name+" #{device}"
       snapshot.save
@@ -73,7 +76,7 @@ class EC2VolumeSnapshoter
 
       @compute.tags.create(:resource_id => snapshot.id, :key =>"application", :value => NAME_PREFIX)
       @compute.tags.create(:resource_id => snapshot.id, :key =>"device", :value => device)
-      @compute.tags.create(:resource_id => snapshot.id, :key =>"instance_id", :value =>instance_id)
+      @compute.tags.create(:resource_id => snapshot.id, :key =>"instance_id", :value =>@instance_id)
       @compute.tags.create(:resource_id => snapshot.id, :key =>"date", :value => ts)
       @compute.tags.create(:resource_id => snapshot.id, :key =>"kind", :value => kind)
 
@@ -106,12 +109,11 @@ class EC2VolumeSnapshoter
   end
 
   # List snapshots for a set of device and a given kind
-  require 'pp'
   def list_snapshots(devices, kind)
     volume_map = []
     snapshots = {}
 
-    tags = @compute.tags.all(:key => 'instance_id', :value => instance_id)
+    tags = @compute.tags.all(:key => 'instance_id', :value => @instance_id)
     tags.each do |tag|
       snap = @compute.snapshots.get(tag.resource_id)
       t =  snap.tags
@@ -129,7 +131,6 @@ class EC2VolumeSnapshoter
     snapshots.delete_if{ |date, snaps| snaps.length != devices.length }
     snapshots
   end
-
 
   def find_volume_for_device(device)
     my = []
@@ -150,16 +151,16 @@ if __FILE__ == $0
   require 'pp'
 
   opts = Trollop::options do
-    opt :access_key_id, "Access Key Id for AWS", :type => :string, :required => true
-    opt :secret_access_key, "Secret Access Key for AWS", :type => :string, :required => true
-    opt :instance_id, "Instance identifier", :type => :string, :required => true
+    opt :access_key_id, "Access Key Id for AWS", :type => :string
+    opt :secret_access_key, "Secret Access Key for AWS", :type => :string
+    opt :instance_id, "Instance identifier", :type => :string
     opt :find_volume_for, "Show information for device path (mount point)", :type => :string
     opt :snapshot, "Snapshot device path (mount point)", :type => :string
-    opt :snapshot_type, "Kind of snapshot (any of #{EC2VolumeSnapshoter::KINDS.keys.join(", ")})", :default => 'test'
+    opt :snapshot_type, "Kind of snapshot (any of #{EC2VolumeSnapshotter::KINDS.keys.join(", ")})", :default => 'test'
 
   end
 
-  evs = EC2VolumeSnapshoter.new(opts[:access_key_id], opts[:secret_access_key], opts[:instance_id])
+  evs = EC2VolumeSnapshotter.new(opts[:access_key_id], opts[:secret_access_key], opts[:instance_id])
   if opts[:find_volume_for]
     pp evs.find_volume_for_device(opts[:find_volume_for])
   end


### PR DESCRIPTION
Hi,

I'm using IAM instance roles, creating a new instance role for each instance I create using Cloudformation.  I don't have to specify keys, etc. when I run mongo_lock_and_snapshot.  Instead, I can just get credentials out of the metadata service.

Therefore, I moved some of the connection related code to a new class: EC2Helper.  I've tested it through a few scenarios (using root AWS credentials and IAM roles) and I've been able to do nearly everything the gem can.

Also, in this pull request are some simple spelling fixes and just a tad bit of love for @geemus's fog.

Thanks!
